### PR TITLE
[REST] Swagger annotations for refactored HTTP model.

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -45,13 +45,13 @@ const docTemplate = `{
                     "200": {
                         "description": "message: healthy",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "503": {
                         "description": "error message with any available details",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -91,25 +91,25 @@ const docTemplate = `{
                     "200": {
                         "description": "The message will contain the Quiz ID of the newly generated quiz",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "409": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -144,19 +144,19 @@ const docTemplate = `{
                     "200": {
                         "description": "The message will contain a confirmation of deletion",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -191,19 +191,19 @@ const docTemplate = `{
                     "200": {
                         "description": "The message will contain a confirmation of publishing",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -250,25 +250,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Score will be in the payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -315,25 +315,25 @@ const docTemplate = `{
                     "200": {
                         "description": "The message will contain a confirmation of the update",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -368,25 +368,25 @@ const docTemplate = `{
                     "200": {
                         "description": "The message will contain the quiz ID and the payload will contain the quiz",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "404": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -433,31 +433,31 @@ const docTemplate = `{
                     "200": {
                         "description": "A page of statistics data",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.StatsResponse"
+                            "$ref": "#/definitions/model_http.StatsResponse"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "404": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -492,31 +492,31 @@ const docTemplate = `{
                     "200": {
                         "description": "Statistics will be in the payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "404": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -551,25 +551,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Score will be in the payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "404": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -601,7 +601,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/model_rest.DeleteUserRequest"
+                            "$ref": "#/definitions/model_http.DeleteUserRequest"
                         }
                     }
                 ],
@@ -609,25 +609,25 @@ const docTemplate = `{
                     "200": {
                         "description": "message with a confirmation of a deleted user account",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "409": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -662,25 +662,25 @@ const docTemplate = `{
                     "200": {
                         "description": "JWT in the api-key",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.JWTAuthResponse"
+                            "$ref": "#/definitions/model_http.JWTAuthResponse"
                         }
                     },
                     "400": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -706,31 +706,31 @@ const docTemplate = `{
                     "200": {
                         "description": "A new valid JWT",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.JWTAuthResponse"
+                            "$ref": "#/definitions/model_http.JWTAuthResponse"
                         }
                     },
                     "400": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "510": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -765,25 +765,25 @@ const docTemplate = `{
                     "200": {
                         "description": "a valid JWT token for the new account",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.JWTAuthResponse"
+                            "$ref": "#/definitions/model_http.JWTAuthResponse"
                         }
                     },
                     "400": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "409": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -963,7 +963,7 @@ const docTemplate = `{
                 }
             }
         },
-        "model_rest.DeleteUserRequest": {
+        "model_http.DeleteUserRequest": {
             "type": "object",
             "required": [
                 "confirmation",
@@ -985,7 +985,7 @@ const docTemplate = `{
                 }
             }
         },
-        "model_rest.Error": {
+        "model_http.Error": {
             "type": "object",
             "properties": {
                 "message": {
@@ -994,7 +994,7 @@ const docTemplate = `{
                 "payload": {}
             }
         },
-        "model_rest.JWTAuthResponse": {
+        "model_http.JWTAuthResponse": {
             "type": "object",
             "required": [
                 "expires",
@@ -1016,7 +1016,7 @@ const docTemplate = `{
                 }
             }
         },
-        "model_rest.StatsResponse": {
+        "model_http.StatsResponse": {
             "type": "object",
             "properties": {
                 "links": {
@@ -1027,16 +1027,11 @@ const docTemplate = `{
                         }
                     }
                 },
-                "metadata": {
-                    "type": "object",
-                    "properties": {
-                        "num_records": {
-                            "type": "integer"
-                        },
-                        "quiz_id": {
-                            "type": "string"
-                        }
-                    }
+                "num_records": {
+                    "type": "integer"
+                },
+                "quiz_id": {
+                    "type": "string"
                 },
                 "records": {
                     "type": "array",
@@ -1046,7 +1041,7 @@ const docTemplate = `{
                 }
             }
         },
-        "model_rest.Success": {
+        "model_http.Success": {
             "type": "object",
             "properties": {
                 "message": {
@@ -1067,7 +1062,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "1.1.0",
+	Version:          "1.5.0",
 	Host:             "localhost:44243",
 	BasePath:         "/api/rest/v1",
 	Schemes:          []string{"http"},

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -21,7 +21,7 @@
             "name": "GPL-3.0",
             "url": "https://opensource.org/licenses/GPL-3.0"
         },
-        "version": "1.1.0"
+        "version": "1.5.0"
     },
     "host": "localhost:44243",
     "basePath": "/api/rest/v1",
@@ -41,13 +41,13 @@
                     "200": {
                         "description": "message: healthy",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "503": {
                         "description": "error message with any available details",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -87,25 +87,25 @@
                     "200": {
                         "description": "The message will contain the Quiz ID of the newly generated quiz",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "409": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -140,19 +140,19 @@
                     "200": {
                         "description": "The message will contain a confirmation of deletion",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -187,19 +187,19 @@
                     "200": {
                         "description": "The message will contain a confirmation of publishing",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -246,25 +246,25 @@
                     "200": {
                         "description": "Score will be in the payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -311,25 +311,25 @@
                     "200": {
                         "description": "The message will contain a confirmation of the update",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -364,25 +364,25 @@
                     "200": {
                         "description": "The message will contain the quiz ID and the payload will contain the quiz",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "404": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -429,31 +429,31 @@
                     "200": {
                         "description": "A page of statistics data",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.StatsResponse"
+                            "$ref": "#/definitions/model_http.StatsResponse"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "404": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -488,31 +488,31 @@
                     "200": {
                         "description": "Statistics will be in the payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "404": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -547,25 +547,25 @@
                     "200": {
                         "description": "Score will be in the payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "404": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "Error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -597,7 +597,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/model_rest.DeleteUserRequest"
+                            "$ref": "#/definitions/model_http.DeleteUserRequest"
                         }
                     }
                 ],
@@ -605,25 +605,25 @@
                     "200": {
                         "description": "message with a confirmation of a deleted user account",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Success"
+                            "$ref": "#/definitions/model_http.Success"
                         }
                     },
                     "400": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "409": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -658,25 +658,25 @@
                     "200": {
                         "description": "JWT in the api-key",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.JWTAuthResponse"
+                            "$ref": "#/definitions/model_http.JWTAuthResponse"
                         }
                     },
                     "400": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -702,31 +702,31 @@
                     "200": {
                         "description": "A new valid JWT",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.JWTAuthResponse"
+                            "$ref": "#/definitions/model_http.JWTAuthResponse"
                         }
                     },
                     "400": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "403": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "510": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -761,25 +761,25 @@
                     "200": {
                         "description": "a valid JWT token for the new account",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.JWTAuthResponse"
+                            "$ref": "#/definitions/model_http.JWTAuthResponse"
                         }
                     },
                     "400": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "409": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     },
                     "500": {
                         "description": "error message with any available details in payload",
                         "schema": {
-                            "$ref": "#/definitions/model_rest.Error"
+                            "$ref": "#/definitions/model_http.Error"
                         }
                     }
                 }
@@ -959,7 +959,7 @@
                 }
             }
         },
-        "model_rest.DeleteUserRequest": {
+        "model_http.DeleteUserRequest": {
             "type": "object",
             "required": [
                 "confirmation",
@@ -981,7 +981,7 @@
                 }
             }
         },
-        "model_rest.Error": {
+        "model_http.Error": {
             "type": "object",
             "properties": {
                 "message": {
@@ -990,7 +990,7 @@
                 "payload": {}
             }
         },
-        "model_rest.JWTAuthResponse": {
+        "model_http.JWTAuthResponse": {
             "type": "object",
             "required": [
                 "expires",
@@ -1012,7 +1012,7 @@
                 }
             }
         },
-        "model_rest.StatsResponse": {
+        "model_http.StatsResponse": {
             "type": "object",
             "properties": {
                 "links": {
@@ -1023,16 +1023,11 @@
                         }
                     }
                 },
-                "metadata": {
-                    "type": "object",
-                    "properties": {
-                        "num_records": {
-                            "type": "integer"
-                        },
-                        "quiz_id": {
-                            "type": "string"
-                        }
-                    }
+                "num_records": {
+                    "type": "integer"
+                },
+                "quiz_id": {
+                    "type": "string"
                 },
                 "records": {
                     "type": "array",
@@ -1042,7 +1037,7 @@
                 }
             }
         },
-        "model_rest.Success": {
+        "model_http.Success": {
             "type": "object",
             "properties": {
                 "message": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -131,7 +131,7 @@ definitions:
     - password
     - username
     type: object
-  model_rest.DeleteUserRequest:
+  model_http.DeleteUserRequest:
     properties:
       confirmation:
         type: string
@@ -147,13 +147,13 @@ definitions:
     - password
     - username
     type: object
-  model_rest.Error:
+  model_http.Error:
     properties:
       message:
         type: string
       payload: {}
     type: object
-  model_rest.JWTAuthResponse:
+  model_http.JWTAuthResponse:
     properties:
       expires:
         description: Expiration time as unix time stamp. Strictly used by client to
@@ -171,26 +171,23 @@ definitions:
     - threshold
     - token
     type: object
-  model_rest.StatsResponse:
+  model_http.StatsResponse:
     properties:
       links:
         properties:
           next_page:
             type: string
         type: object
-      metadata:
-        properties:
-          num_records:
-            type: integer
-          quiz_id:
-            type: string
-        type: object
+      num_records:
+        type: integer
+      quiz_id:
+        type: string
       records:
         items:
           $ref: '#/definitions/model_cassandra.Response'
         type: array
     type: object
-  model_rest.Success:
+  model_http.Success:
     properties:
       message:
         type: string
@@ -209,7 +206,7 @@ info:
     name: GPL-3.0
     url: https://opensource.org/licenses/GPL-3.0
   title: Multiple Choice Question Platform.
-  version: 1.1.0
+  version: 1.5.0
 paths:
   /health:
     get:
@@ -222,11 +219,11 @@ paths:
         "200":
           description: 'message: healthy'
           schema:
-            $ref: '#/definitions/model_rest.Success'
+            $ref: '#/definitions/model_http.Success'
         "503":
           description: error message with any available details
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       summary: Healthcheck for service liveness.
       tags:
       - health healthcheck liveness
@@ -252,19 +249,19 @@ paths:
           description: The message will contain the Quiz ID of the newly generated
             quiz
           schema:
-            $ref: '#/definitions/model_rest.Success'
+            $ref: '#/definitions/model_http.Success'
         "400":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "409":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: Create a quiz.
@@ -287,15 +284,15 @@ paths:
         "200":
           description: The message will contain a confirmation of deletion
           schema:
-            $ref: '#/definitions/model_rest.Success'
+            $ref: '#/definitions/model_http.Success'
         "403":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: Delete a quiz.
@@ -319,15 +316,15 @@ paths:
         "200":
           description: The message will contain a confirmation of publishing
           schema:
-            $ref: '#/definitions/model_rest.Success'
+            $ref: '#/definitions/model_http.Success'
         "403":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: Publish a quiz.
@@ -358,19 +355,19 @@ paths:
         "200":
           description: Score will be in the payload
           schema:
-            $ref: '#/definitions/model_rest.Success'
+            $ref: '#/definitions/model_http.Success'
         "400":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "403":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: Take a quiz.
@@ -401,19 +398,19 @@ paths:
         "200":
           description: The message will contain a confirmation of the update
           schema:
-            $ref: '#/definitions/model_rest.Success'
+            $ref: '#/definitions/model_http.Success'
         "400":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "403":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: Update a quiz.
@@ -437,19 +434,19 @@ paths:
           description: The message will contain the quiz ID and the payload will contain
             the quiz
           schema:
-            $ref: '#/definitions/model_rest.Success'
+            $ref: '#/definitions/model_http.Success'
         "403":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "404":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: View a quiz.
@@ -482,23 +479,23 @@ paths:
         "200":
           description: A page of statistics data
           schema:
-            $ref: '#/definitions/model_rest.StatsResponse'
+            $ref: '#/definitions/model_http.StatsResponse'
         "400":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "403":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "404":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: Get paginated statistics associated with a specific test.
@@ -522,23 +519,23 @@ paths:
         "200":
           description: Statistics will be in the payload
           schema:
-            $ref: '#/definitions/model_rest.Success'
+            $ref: '#/definitions/model_http.Success'
         "400":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "403":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "404":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: Get all statistics associated with a specific test.
@@ -561,19 +558,19 @@ paths:
         "200":
           description: Score will be in the payload
           schema:
-            $ref: '#/definitions/model_rest.Success'
+            $ref: '#/definitions/model_http.Success'
         "400":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "404":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: Error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: Get a user's score.
@@ -594,26 +591,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/model_rest.DeleteUserRequest'
+          $ref: '#/definitions/model_http.DeleteUserRequest'
       produces:
       - application/json
       responses:
         "200":
           description: message with a confirmation of a deleted user account
           schema:
-            $ref: '#/definitions/model_rest.Success'
+            $ref: '#/definitions/model_http.Success'
         "400":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "409":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: Deletes a user. The user must supply their credentials as well as a
@@ -639,19 +636,19 @@ paths:
         "200":
           description: JWT in the api-key
           schema:
-            $ref: '#/definitions/model_rest.JWTAuthResponse'
+            $ref: '#/definitions/model_http.JWTAuthResponse'
         "400":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "403":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       summary: Login a user.
       tags:
       - user users login security
@@ -666,23 +663,23 @@ paths:
         "200":
           description: A new valid JWT
           schema:
-            $ref: '#/definitions/model_rest.JWTAuthResponse'
+            $ref: '#/definitions/model_http.JWTAuthResponse'
         "400":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "403":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "510":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       security:
       - ApiKeyAuth: []
       summary: Refresh a user's JWT by extending its expiration time.
@@ -708,19 +705,19 @@ paths:
         "200":
           description: a valid JWT token for the new account
           schema:
-            $ref: '#/definitions/model_rest.JWTAuthResponse'
+            $ref: '#/definitions/model_http.JWTAuthResponse'
         "400":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "409":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
         "500":
           description: error message with any available details in payload
           schema:
-            $ref: '#/definitions/model_rest.Error'
+            $ref: '#/definitions/model_http.Error'
       summary: Register a user.
       tags:
       - user users register security

--- a/pkg/http/rest/handlers/healthcheck.go
+++ b/pkg/http/rest/handlers/healthcheck.go
@@ -17,8 +17,8 @@ import (
 // @Tags        health healthcheck liveness
 // @Id          healthcheck
 // @Produce     json
-// @Success     200 {object} model_rest.Success "message: healthy"
-// @Failure     503 {object} model_rest.Error   "error message with any available details"
+// @Success     200 {object} model_http.Success "message: healthy"
+// @Failure     503 {object} model_http.Error   "error message with any available details"
 // @Router      /health [get]
 func Healthcheck(logger *logger.Logger, db cassandra.Cassandra, cache redis.Redis) gin.HandlerFunc {
 	return func(context *gin.Context) {

--- a/pkg/http/rest/handlers/quiz.go
+++ b/pkg/http/rest/handlers/quiz.go
@@ -25,10 +25,10 @@ import (
 // @Produce     json
 // @Security    ApiKeyAuth
 // @Param       quiz_id path     string             true "The quiz ID for the quiz being requested."
-// @Success     200     {object} model_rest.Success "The message will contain the quiz ID and the payload will contain the quiz"
-// @Failure     403     {object} model_rest.Error   "Error message with any available details in payload"
-// @Failure     404     {object} model_rest.Error   "Error message with any available details in payload"
-// @Failure     500     {object} model_rest.Error   "Error message with any available details in payload"
+// @Success     200     {object} model_http.Success "The message will contain the quiz ID and the payload will contain the quiz"
+// @Failure     403     {object} model_http.Error   "Error message with any available details in payload"
+// @Failure     404     {object} model_http.Error   "Error message with any available details in payload"
+// @Failure     500     {object} model_http.Error   "Error message with any available details in payload"
 // @Router      /quiz/view/{quiz_id} [get]
 func ViewQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra, cache redis.Redis) gin.HandlerFunc {
 	return func(context *gin.Context) {
@@ -88,10 +88,10 @@ func ViewQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra, cac
 // @Produce     json
 // @Security    ApiKeyAuth
 // @Param       quiz body     model_cassandra.QuizCore true "The Quiz to be created as unpublished"
-// @Success     200  {object} model_rest.Success       "The message will contain the Quiz ID of the newly generated quiz"
-// @Failure     400  {object} model_rest.Error         "Error message with any available details in payload"
-// @Failure     409  {object} model_rest.Error         "Error message with any available details in payload"
-// @Failure     500  {object} model_rest.Error         "Error message with any available details in payload"
+// @Success     200  {object} model_http.Success       "The message will contain the Quiz ID of the newly generated quiz"
+// @Failure     400  {object} model_http.Error         "Error message with any available details in payload"
+// @Failure     409  {object} model_http.Error         "Error message with any available details in payload"
+// @Failure     500  {object} model_http.Error         "Error message with any available details in payload"
 // @Router      /quiz/create/ [post]
 func CreateQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) gin.HandlerFunc {
 	return func(context *gin.Context) {
@@ -145,10 +145,10 @@ func CreateQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) g
 // @Security    ApiKeyAuth
 // @Param       quiz_id path     string                   true "The Test ID for the quiz being updated."
 // @Param       quiz    body     model_cassandra.QuizCore true "The Quiz to replace the one already submitted"
-// @Success     200     {object} model_rest.Success       "The message will contain a confirmation of the update"
-// @Failure     400     {object} model_rest.Error         "Error message with any available details in payload"
-// @Failure     403     {object} model_rest.Error         "Error message with any available details in payload"
-// @Failure     500     {object} model_rest.Error         "Error message with any available details in payload"
+// @Success     200     {object} model_http.Success       "The message will contain a confirmation of the update"
+// @Failure     400     {object} model_http.Error         "Error message with any available details in payload"
+// @Failure     403     {object} model_http.Error         "Error message with any available details in payload"
+// @Failure     500     {object} model_http.Error         "Error message with any available details in payload"
 // @Router      /quiz/update/{quiz_id} [patch]
 func UpdateQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) gin.HandlerFunc {
 	return func(context *gin.Context) {
@@ -206,9 +206,9 @@ func UpdateQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) g
 // @Produce     json
 // @Security    ApiKeyAuth
 // @Param       quiz_id path     string             true "The Test ID for the quiz being deleted."
-// @Success     200     {object} model_rest.Success "The message will contain a confirmation of deletion"
-// @Failure     403     {object} model_rest.Error   "Error message with any available details in payload"
-// @Failure     500     {object} model_rest.Error   "Error message with any available details in payload"
+// @Success     200     {object} model_http.Success "The message will contain a confirmation of deletion"
+// @Failure     403     {object} model_http.Error   "Error message with any available details in payload"
+// @Failure     500     {object} model_http.Error   "Error message with any available details in payload"
 // @Router      /quiz/delete/{quiz_id} [delete]
 func DeleteQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra, cache redis.Redis) gin.HandlerFunc {
 	return func(context *gin.Context) {
@@ -280,9 +280,9 @@ func DeleteQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra, c
 // @Produce     json
 // @Security    ApiKeyAuth
 // @Param       quiz_id path     string             true "The Test ID for the quiz being published."
-// @Success     200     {object} model_rest.Success "The message will contain a confirmation of publishing"
-// @Failure     403     {object} model_rest.Error   "Error message with any available details in payload"
-// @Failure     500     {object} model_rest.Error   "Error message with any available details in payload"
+// @Success     200     {object} model_http.Success "The message will contain a confirmation of publishing"
+// @Failure     403     {object} model_http.Error   "Error message with any available details in payload"
+// @Failure     500     {object} model_http.Error   "Error message with any available details in payload"
 // @Router      /quiz/publish/{quiz_id} [patch]
 func PublishQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra, cache redis.Redis) gin.HandlerFunc {
 	return func(context *gin.Context) {
@@ -347,10 +347,10 @@ func PublishQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra, 
 // @Security    ApiKeyAuth
 // @Param       quiz_id path     string                       true "The Test ID for the answers being submitted."
 // @Param       answers body     model_cassandra.QuizResponse true "The answer card to be submitted."
-// @Success     200     {object} model_rest.Success           "Score will be in the payload"
-// @Failure     400     {object} model_rest.Error             "Error message with any available details in payload"
-// @Failure     403     {object} model_rest.Error             "Error message with any available details in payload"
-// @Failure     500     {object} model_rest.Error             "Error message with any available details in payload"
+// @Success     200     {object} model_http.Success           "Score will be in the payload"
+// @Failure     400     {object} model_http.Error             "Error message with any available details in payload"
+// @Failure     403     {object} model_http.Error             "Error message with any available details in payload"
+// @Failure     500     {object} model_http.Error             "Error message with any available details in payload"
 // @Router      /quiz/take/{quiz_id} [post]
 func TakeQuiz(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra, cache redis.Redis, grader grading.Grading) gin.HandlerFunc {
 	return func(context *gin.Context) {

--- a/pkg/http/rest/handlers/score.go
+++ b/pkg/http/rest/handlers/score.go
@@ -24,10 +24,10 @@ import (
 // @Produce     json
 // @Security    ApiKeyAuth
 // @Param       quiz_id path     string             true "The Test ID for the requested scorecard."
-// @Success     200     {object} model_rest.Success "Score will be in the payload"
-// @Failure     400     {object} model_rest.Error   "Error message with any available details in payload"
-// @Failure     404     {object} model_rest.Error   "Error message with any available details in payload"
-// @Failure     500     {object} model_rest.Error   "Error message with any available details in payload"
+// @Success     200     {object} model_http.Success "Score will be in the payload"
+// @Failure     400     {object} model_http.Error   "Error message with any available details in payload"
+// @Failure     404     {object} model_http.Error   "Error message with any available details in payload"
+// @Failure     500     {object} model_http.Error   "Error message with any available details in payload"
 // @Router      /score/test/{quiz_id} [get]
 func GetScore(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) gin.HandlerFunc {
 	return func(context *gin.Context) {
@@ -74,11 +74,11 @@ func GetScore(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) gin
 // @Produce     json
 // @Security    ApiKeyAuth
 // @Param       quiz_id path     string             true "The Test ID for the requested statistics."
-// @Success     200     {object} model_rest.Success "Statistics will be in the payload"
-// @Failure     400     {object} model_rest.Error   "Error message with any available details in payload"
-// @Failure     403     {object} model_rest.Error   "Error message with any available details in payload"
-// @Failure     404     {object} model_rest.Error   "Error message with any available details in payload"
-// @Failure     500     {object} model_rest.Error   "Error message with any available details in payload"
+// @Success     200     {object} model_http.Success "Statistics will be in the payload"
+// @Failure     400     {object} model_http.Error   "Error message with any available details in payload"
+// @Failure     403     {object} model_http.Error   "Error message with any available details in payload"
+// @Failure     404     {object} model_http.Error   "Error message with any available details in payload"
+// @Failure     500     {object} model_http.Error   "Error message with any available details in payload"
 // @Router      /score/stats/{quiz_id} [get]
 func GetStats(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) gin.HandlerFunc {
 	return func(context *gin.Context) {
@@ -134,11 +134,11 @@ func GetStats(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) gin
 // @Param       quiz_id    path     string                   true  "The Test ID for the requested statistics."
 // @Param       pageCursor query    string                   false "The page cursor into the query results records."
 // @Param       pageSize   query    int                      false "The number of records to retrieve on this page."
-// @Success     200        {object} model_rest.StatsResponse "A page of statistics data"
-// @Failure     400        {object} model_rest.Error         "Error message with any available details in payload"
-// @Failure     403        {object} model_rest.Error         "Error message with any available details in payload"
-// @Failure     404        {object} model_rest.Error         "Error message with any available details in payload"
-// @Failure     500        {object} model_rest.Error         "Error message with any available details in payload"
+// @Success     200        {object} model_http.StatsResponse "A page of statistics data"
+// @Failure     400        {object} model_http.Error         "Error message with any available details in payload"
+// @Failure     403        {object} model_http.Error         "Error message with any available details in payload"
+// @Failure     404        {object} model_http.Error         "Error message with any available details in payload"
+// @Failure     500        {object} model_http.Error         "Error message with any available details in payload"
 // @Router      /score/stats-paged/{quiz_id} [get]
 func GetStatsPage(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) gin.HandlerFunc {
 	return func(context *gin.Context) {

--- a/pkg/http/rest/handlers/users.go
+++ b/pkg/http/rest/handlers/users.go
@@ -25,10 +25,10 @@ import (
 // @Accept      json
 // @Produce     json
 // @Param       user body     model_cassandra.UserAccount true "Username, password, first and last name, email address of user"
-// @Success     200  {object} model_rest.JWTAuthResponse  "a valid JWT token for the new account"
-// @Failure     400  {object} model_rest.Error            "error message with any available details in payload"
-// @Failure     409  {object} model_rest.Error            "error message with any available details in payload"
-// @Failure     500  {object} model_rest.Error            "error message with any available details in payload"
+// @Success     200  {object} model_http.JWTAuthResponse  "a valid JWT token for the new account"
+// @Failure     400  {object} model_http.Error            "error message with any available details in payload"
+// @Failure     409  {object} model_http.Error            "error message with any available details in payload"
+// @Failure     500  {object} model_http.Error            "error message with any available details in payload"
 // @Router      /user/register [post]
 func RegisterUser(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) gin.HandlerFunc {
 	return func(context *gin.Context) {
@@ -75,10 +75,10 @@ func RegisterUser(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra)
 // @Accept      json
 // @Produce     json
 // @Param       credentials body     model_cassandra.UserLoginCredentials true "Username and password to login with"
-// @Success     200         {object} model_rest.JWTAuthResponse           "JWT in the api-key"
-// @Failure     400         {object} model_rest.Error                     "error message with any available details in payload"
-// @Failure     403         {object} model_rest.Error                     "error message with any available details in payload"
-// @Failure     500         {object} model_rest.Error                     "error message with any available details in payload"
+// @Success     200         {object} model_http.JWTAuthResponse           "JWT in the api-key"
+// @Failure     400         {object} model_http.Error                     "error message with any available details in payload"
+// @Failure     403         {object} model_http.Error                     "error message with any available details in payload"
+// @Failure     500         {object} model_http.Error                     "error message with any available details in payload"
 // @Router      /user/login [post]
 func LoginUser(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) gin.HandlerFunc {
 	return func(context *gin.Context) {
@@ -125,11 +125,11 @@ func LoginUser(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra) gi
 // @Id          loginRefresh
 // @Produce     json
 // @Security    ApiKeyAuth
-// @Success     200 {object} model_rest.JWTAuthResponse "A new valid JWT"
-// @Failure     400 {object} model_rest.Error           "error message with any available details in payload"
-// @Failure     403 {object} model_rest.Error           "error message with any available details in payload"
-// @Failure     500 {object} model_rest.Error           "error message with any available details in payload"
-// @Failure     510 {object} model_rest.Error           "error message with any available details in payload"
+// @Success     200 {object} model_http.JWTAuthResponse "A new valid JWT"
+// @Failure     400 {object} model_http.Error           "error message with any available details in payload"
+// @Failure     403 {object} model_http.Error           "error message with any available details in payload"
+// @Failure     500 {object} model_http.Error           "error message with any available details in payload"
+// @Failure     510 {object} model_http.Error           "error message with any available details in payload"
 // @Router      /user/refresh [post]
 func LoginRefresh(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra, authHeaderKey string) gin.HandlerFunc {
 	return func(context *gin.Context) {
@@ -181,11 +181,11 @@ func LoginRefresh(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra,
 // @Accept      json
 // @Produce     json
 // @Security    ApiKeyAuth
-// @Param       request body     model_rest.DeleteUserRequest true "The request payload for deleting an account"
-// @Success     200     {object} model_rest.Success           "message with a confirmation of a deleted user account"
-// @Failure     400     {object} model_rest.Error             "error message with any available details in payload"
-// @Failure     409     {object} model_rest.Error             "error message with any available details in payload"
-// @Failure     500     {object} model_rest.Error             "error message with any available details in payload"
+// @Param       request body     model_http.DeleteUserRequest true "The request payload for deleting an account"
+// @Success     200     {object} model_http.Success           "message with a confirmation of a deleted user account"
+// @Failure     400     {object} model_http.Error             "error message with any available details in payload"
+// @Failure     409     {object} model_http.Error             "error message with any available details in payload"
+// @Failure     500     {object} model_http.Error             "error message with any available details in payload"
 // @Router      /user/delete [delete]
 func DeleteUser(logger *logger.Logger, auth auth.Auth, db cassandra.Cassandra, authHeaderKey string) gin.HandlerFunc {
 	return func(context *gin.Context) {

--- a/pkg/http/rest/rest.go
+++ b/pkg/http/rest/rest.go
@@ -105,7 +105,7 @@ func (s *Server) initialize() {
 	s.router = gin.Default()
 
 	// @title                      Multiple Choice Question Platform.
-	// @version                    1.1.0
+	// @version                    1.5.0
 	// @description                Multiple Choice Question Platform API.
 	// @description                This application supports the creation, managing, marking, viewing, retrieving stats, and scores of quizzes.
 	//


### PR DESCRIPTION
The Swagger annotations have been updated to change the `model_rest` to the refactored `model_http` package.

The version of the API has also been updated to `1.5` given the addition of GraphQL and the fixes to `delete` functionality.