### PR TITLE
[Docker] Redis Cluster Canonical Names

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       retries: 10
 
   redis-node-0:
+    container_name: redis-node-0
     image: docker.io/bitnami/redis-cluster:7.0
     restart: always
     ports:
@@ -39,6 +40,7 @@ services:
       retries: 10
 
   redis-node-1:
+    container_name: redis-node-1
     image: docker.io/bitnami/redis-cluster:7.0
     restart: always
     ports:
@@ -55,6 +57,7 @@ services:
       retries: 10
 
   redis-node-2:
+    container_name: redis-node-2
     image: docker.io/bitnami/redis-cluster:7.0
     restart: always
     ports:
@@ -71,6 +74,7 @@ services:
       retries: 10
 
   redis-node-3:
+    container_name: redis-node-3
     image: docker.io/bitnami/redis-cluster:7.0
     restart: always
     ports:
@@ -87,6 +91,7 @@ services:
       retries: 10
 
   redis-node-4:
+    container_name: redis-node-4
     image: docker.io/bitnami/redis-cluster:7.0
     restart: always
     ports:
@@ -103,6 +108,7 @@ services:
       retries: 10
 
   redis-node-5:
+    container_name: redis-node-5
     image: docker.io/bitnami/redis-cluster:7.0
     restart: always
     ports:


### PR DESCRIPTION
Canonical names for the Redis Cluster node container names have been added:  `redis-node-[0-5]`.